### PR TITLE
/blob/ -> /raw/ in image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Images look like links with an ! in front, for example, an external image can be
 
 You can also upload an image into your repo. 
 
-![vscode image](https://github.com/profcase/working-with-markdown/blob/master/vscode.PNG "Example local image")
+![vscode image](https://github.com/profcase/working-with-markdown/raw/master/vscode.PNG "Example local image")
 
 ## Paragraphs
 


### PR DESCRIPTION
While using /blob/ appears to work in the GitHub preview and repository
view, the image does not load properly when you look at the published
version. This change makes the image link to the true image, instead of
the preview/lightbox (similar to the difficulty with Wikimedia).